### PR TITLE
Add Renderer Module

### DIFF
--- a/lib/opencomponents.rb
+++ b/lib/opencomponents.rb
@@ -1,6 +1,7 @@
 require 'opencomponents/component'
 require 'opencomponents/prerendered_component'
 require 'opencomponents/rendered_component'
+require 'opencomponents/renderer'
 require 'opencomponents/template'
 require 'opencomponents/version'
 

--- a/lib/opencomponents/renderer.rb
+++ b/lib/opencomponents/renderer.rb
@@ -1,0 +1,9 @@
+module OpenComponents
+  module Renderer
+    def render_component(component, params = {}, version = '')
+      OpenComponents::RenderedComponent.new(component, params, version)
+        .load
+        .html
+    end
+  end
+end

--- a/spec/lib/opencomponents/renderer_spec.rb
+++ b/spec/lib/opencomponents/renderer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+class TestRenderer
+  include OpenComponents::Renderer
+end
+
+RSpec.describe OpenComponents::Renderer do
+  describe '#render_component' do
+    before do
+      stub_request(:get, "http://localhost:3030/foobar/1.0.1").
+        with(headers: {'Accept'=>'', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
+            query: {name: 'foobar'}).
+        to_return(status: 200, body: '{"href":"http://localhost:3030/foobar/1.0.1?name=foobar","type":"oc-component-local","version":"1.0.1","requestVersion":"1.0.1","html":"<oc-component href=\"http://localhost:3030/foobar/1.0.1?name=foobar\" data-hash=\"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea\" id=\"8502960618\" data-rendered=\"true\" data-version=\"1.0.0\"><h1>ohai, my name is foobar</h1></oc-component>","renderMode":"rendered"}', headers: {})
+
+      stub_request(:get, "http://localhost:3030/barfoo/").
+        with(headers: {'Accept'=>'', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
+        to_return(status: 404, body: "", headers: {})
+    end
+
+    let(:renderer) { TestRenderer.new }
+
+    it 'returns the HTML for a component' do
+      expect(renderer.render_component(
+        'foobar', {name: 'foobar'}, '1.0.1'
+      )).to eq "<oc-component href=\"http://localhost:3030/foobar/1.0.1?name=foobar\" data-hash=\"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea\" id=\"8502960618\" data-rendered=\"true\" data-version=\"1.0.0\"><h1>ohai, my name is foobar</h1></oc-component>"
+    end
+
+    it 'raises an error if the component is not found' do
+      expect { renderer.render_component('barfoo') }
+        .to raise_exception(OpenComponents::ComponentNotFound)
+    end
+  end
+end


### PR DESCRIPTION
This will allow us to mix in a renderer for templating engines.

I think, for the moment, I'm going to hold off on adding a renderer for `PrerenderedComponent`s. My initial thought was that I'd consume the OC renderer with `ExecJS` or something similar and render the template with that. However, doing so would give us 1) the same output as the `html` attribute on `RenderedComponent` (which is expected) and 2) would violate the entire idea behind providing `pre-rendered` templates (that idea being that that data is provided for you to use your own implementation of the renderer). At some point, it might be interesting to recreate the renderer in pure Ruby, but I don't see much of an advantage to doing so at this point.

Obligatory GIF:
![uhmn0dq](https://cloud.githubusercontent.com/assets/120350/8388117/a1c80516-1c13-11e5-8f74-822e77802bb1.gif)
