### PR TITLE
Add Rails Compatibility

### DIFF
--- a/lib/opencomponents.rb
+++ b/lib/opencomponents.rb
@@ -4,7 +4,8 @@ require 'opencomponents/rendered_component'
 require 'opencomponents/renderer'
 require 'opencomponents/version'
 
-require 'opencomponents/sinatra_helpers' if defined?(Sinatra)
+require 'opencomponents/railtie' if defined? Rails
+require 'opencomponents/sinatra_helpers' if defined? Sinatra
 
 module OpenComponents
   DEFAULT_REGISTRY = 'http://localhost:3030'

--- a/lib/opencomponents/railtie.rb
+++ b/lib/opencomponents/railtie.rb
@@ -1,0 +1,24 @@
+module OpenComponents
+  module RailsRenderer
+    include Renderer
+
+    def render_component(component, params = {}, version = '')
+      super(component, params, version).html_safe
+    end
+  end
+
+  class Railtie < ::Rails::Railtie
+    config.opencomponents = ActiveSupport::OrderedOptions.new
+
+    initializer 'opencomponents.configure' do |app|
+      OpenComponents.configure do |config|
+        config.registry = app.config.opencomponents.registry ||
+          OpenComponents::DEFAULT_REGISTRY
+      end
+    end
+
+    initializer 'opencomponents.view_helpers' do
+      ActionView::Base.send :include, OpenComponents::RailsRenderer
+    end
+  end
+end


### PR DESCRIPTION
First pass at Rails compatibility. Could use some tests (same with the Sinatra helper), but I'll need to restructure the tests to do that. Maybe I'll add some actual integration tests for those at some point. Anyway, this is just a basic Rails integration for rendering components in views - I still need to look into component caching and hooking into the asset pipeline, though I'm concerned about extending the scope of this gem too far.

I think the roadmap for this gem moving forward will be to extract the Rails-/Sinatra-specific bits into their own gems. That should prevent this gem from getting too bloated and allow it to focus on its core scope of consuming components while leaving the rendering up to the individual framework. Let's merge this in until then, though.

![brownkick](https://cloud.githubusercontent.com/assets/120350/8443846/2a34738e-1f3f-11e5-94a9-c3f923539875.gif)
