### PR TITLE
Add Custom RegistryTimeout Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.3.0
+ * Changes:
+  * Registry request timeouts now raise `OpenComponents::RegistryTimeout`.
+
 ## 0.2.0
  * Changes:
-  * Changed Component initialization to accept an unordered options Hash for
+  * Changed Component initialization to accept an options Hash for
     optional arguments.
     
     ```ruby

--- a/lib/opencomponents.rb
+++ b/lib/opencomponents.rb
@@ -1,3 +1,5 @@
+require 'rest-client'
+
 require 'opencomponents/component'
 require 'opencomponents/prerendered_component'
 require 'opencomponents/rendered_component'
@@ -11,6 +13,9 @@ module OpenComponents
   # Internal: Custom exception class to raise in the event a component cannot be
   #   found in the registry.
   ComponentNotFound = Class.new(RuntimeError)
+
+  # Internal: Custom exception class to raise for response timeouts.
+  RegistryTimeout = Class.new(RestClient::RequestTimeout)
 
   # Internal: Stores configuration data.
   #

--- a/lib/opencomponents/component.rb
+++ b/lib/opencomponents/component.rb
@@ -1,5 +1,3 @@
-require 'rest-client'
-
 module OpenComponents
   # Wrapper object for a component fetched from an OC registry.
   class Component
@@ -113,6 +111,7 @@ module OpenComponents
     # Returns a response body String.
     # Raises OpenComponents::ComponentNotFound if the registry responds with a
     #   404.
+    # Raises OpenComponents::RegistryTimeout if the request times out.
     def response
       request_headers = headers.merge(params: params)
 
@@ -124,6 +123,8 @@ module OpenComponents
       )
     rescue RestClient::ResourceNotFound => e
       fail ComponentNotFound, e.message
+    rescue RestClient::RequestTimeout => e
+      fail RegistryTimeout, e.message
     end
 
     # Internal: Helper method for converting and memoizing registry response

--- a/spec/lib/opencomponents/prerendered_component_spec.rb
+++ b/spec/lib/opencomponents/prerendered_component_spec.rb
@@ -195,20 +195,32 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         expect { subject }.to raise_exception(OpenComponents::ComponentNotFound)
       end
     end
-  end
 
-  context 'with custom HTTP headers' do
-    let!(:stub) do
-      stub_request(:get, "http://localhost:3030/foobar/").
-        with(:headers => {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
-        to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', :headers => {})
+    context 'for a registry timeout' do
+      before do
+        stub_request(:get, "http://localhost:3030/foo/").to_timeout
+      end
+
+      subject { described_class.new('foo').load }
+
+      it 'raises an exception' do
+        expect { subject }.to raise_exception(OpenComponents::RegistryTimeout)
+      end
     end
 
-    subject { described_class.new('foobar', headers: {accept_language: 'emoji'}).load }
+    context 'with custom HTTP headers' do
+      let!(:stub) do
+        stub_request(:get, "http://localhost:3030/foobar/").
+          with(:headers => {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
+          to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', :headers => {})
+      end
 
-    it 'includes custom headers in the request' do
-      subject
-      expect(stub).to have_been_requested
+      subject { described_class.new('foobar', headers: {accept_language: 'emoji'}).load }
+
+      it 'includes custom headers in the request' do
+        subject
+        expect(stub).to have_been_requested
+      end
     end
   end
 

--- a/spec/lib/opencomponents/rendered_component_spec.rb
+++ b/spec/lib/opencomponents/rendered_component_spec.rb
@@ -162,20 +162,32 @@ RSpec.describe OpenComponents::RenderedComponent do
         expect { subject }.to raise_exception(OpenComponents::ComponentNotFound)
       end
     end
-  end
 
-  context 'with custom HTTP headers' do
-    let!(:stub) do
-      stub_request(:get, "http://localhost:3030/foobar/").
-        with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
-        to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","html":"<oc-component href=\"http://localhost:3030/foobar\" data-hash=\"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea\" id=\"8502960618\" data-rendered=\"true\" data-version=\"1.0.0\"><h1>ohai, my name is Todd</h1></oc-component>","renderMode":"rendered"}', :headers => {})
+    context 'for a registry timeout' do
+      before do
+        stub_request(:get, "http://localhost:3030/foo/").to_timeout
+      end
+
+      subject { described_class.new('foo').load }
+
+      it 'raises an exception' do
+        expect { subject }.to raise_exception(OpenComponents::RegistryTimeout)
+      end
     end
 
-    subject { described_class.new('foobar', headers: {accept_language: 'emoji'}).load }
+    context 'with custom HTTP headers' do
+      let!(:stub) do
+        stub_request(:get, "http://localhost:3030/foobar/").
+          with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
+          to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","html":"<oc-component href=\"http://localhost:3030/foobar\" data-hash=\"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea\" id=\"8502960618\" data-rendered=\"true\" data-version=\"1.0.0\"><h1>ohai, my name is Todd</h1></oc-component>","renderMode":"rendered"}', :headers => {})
+      end
 
-    it 'includes custom headers in the request' do
-      subject
-      expect(stub).to have_been_requested
+      subject { described_class.new('foobar', headers: {accept_language: 'emoji'}).load }
+
+      it 'includes custom headers in the request' do
+        subject
+        expect(stub).to have_been_requested
+      end
     end
   end
 


### PR DESCRIPTION
Going to need to `rescue` from this in the Rails helper. Will cut a new version once this is merged.

RestClient 2.0 is also going to do away with `RestClient::RequestTimeout` in favor of two separate exceptions subclassed from a new `RestClient::Exceptions::Timeout`. This change will allow us to handle that change in a backwards-compatible fashion.

![mcs4pgj](https://cloud.githubusercontent.com/assets/120350/8584680/0a44c772-258e-11e5-8c9b-683fabbadb28.gif)
