### PR TITLE
Configurable Timeout Length

### DIFF
--- a/lib/opencomponents.rb
+++ b/lib/opencomponents.rb
@@ -10,17 +10,20 @@ module OpenComponents
   # Public: Default OC registry URL (http://localhost:3030).
   DEFAULT_REGISTRY = 'http://localhost:3030'
 
+  # Public: Default request timeout in seconds (5)
+  DEFAULT_TIMEOUT = 5
+
   # Internal: Custom exception class to raise in the event a component cannot be
   #   found in the registry.
   ComponentNotFound = Class.new(RuntimeError)
 
   # Internal: Custom exception class to raise for response timeouts.
-  RegistryTimeout = Class.new(RestClient::RequestTimeout)
+  RegistryTimeout = Class.new(RuntimeError)
 
   # Internal: Stores configuration data.
   #
   # registry - String for the registry host.
-  Configuration = Struct.new(:registry)
+  Configuration = Struct.new(:registry, :timeout)
 
   # Internal: Wrapper object for pre-rendered OC templates.
   #
@@ -33,7 +36,7 @@ module OpenComponents
   #
   # Returns the Configuration if set, a default Configuration if not set.
   def self.config
-    @@_config ||= Configuration.new(DEFAULT_REGISTRY)
+    @@_config ||= Configuration.new(DEFAULT_REGISTRY, DEFAULT_TIMEOUT)
   end
 
   # Public: Setter for Configuration.

--- a/lib/opencomponents/component.rb
+++ b/lib/opencomponents/component.rb
@@ -118,7 +118,7 @@ module OpenComponents
       RestClient::Request.execute(
         method: :get,
         url: url,
-        timeout: 10,
+        timeout: OpenComponents.config.timeout,
         headers: request_headers
       )
     rescue RestClient::ResourceNotFound => e

--- a/spec/lib/opencomponents_spec.rb
+++ b/spec/lib/opencomponents_spec.rb
@@ -15,5 +15,19 @@ RSpec.describe OpenComponents do
         expect(described_class.config.registry).to eq('http://localhost:3030')
       end
     end
+
+    context 'with a custom timeout' do
+      it 'sets the custom timeout within the configuration' do
+        described_class.configure { |c| c.timeout = 10 }
+        expect(described_class.config.timeout).to eq 10
+      end
+    end
+
+    context 'without a custom timeout' do
+      it 'sets the default timeout' do
+        described_class.configure { |_| } #No-op
+        expect(described_class.config.timeout).to eq 5
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows the timeout length to be configurable. Also fixes an issue where catching a timeout could result in an infinite loop (derp).

![qkhtcdk](https://cloud.githubusercontent.com/assets/120350/8585630/7ffb5c82-2599-11e5-844b-262c0bb69968.gif)
