### PR TITLE
prerendered -> unrendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0
+ * Changes:
+  * OpenComponents::PrerenderedComponent is now OpenComponents::UnrenderedComponent
+
 ## 0.4.0
  * Changes:
   * Default request timeout length shortened to 5 seconds.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    opencomponents (0.4.0)
+    opencomponents (0.5.0)
       rest-client (~> 1.8)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ component = OpenComponents::RenderedComponent.new(
 )
 ```
 
-## Getting Pre-rendered Components
-If you'd like to perform the component rendering yourself, you can request a
-pre-rendered component from a registry using a `PrerenderedComponent` object.
+## Getting Unrendered Components
+If you'd like to perform the component rendering yourself, you can request an
+unrendered component from a registry using a `UnrenderedComponent` object.
 ```ruby
-component = OpenComponents::PrerenderedComponent.new('my-awesome-component')
+component = OpenComponents::UnrenderedComponent.new('my-awesome-component')
 component.load
 ```
 
 You can use the same optional `params`, `version`, and `headers` arguments as
 `RenderedComponent`s.
 
-**Note**: `PrerenderedComponent`s will only fetch component data for you - they
+**Note**: `UnrenderedComponent`s will only fetch component data for you - they
 do not provide an interface for rendering them. At the moment, it's up to you to
 determine the best way to render the template.
 

--- a/lib/opencomponents.rb
+++ b/lib/opencomponents.rb
@@ -1,9 +1,9 @@
 require 'rest-client'
 
 require 'opencomponents/component'
-require 'opencomponents/prerendered_component'
 require 'opencomponents/rendered_component'
 require 'opencomponents/renderer'
+require 'opencomponents/unrendered_component'
 require 'opencomponents/version'
 
 module OpenComponents
@@ -25,7 +25,7 @@ module OpenComponents
   # registry - String for the registry host.
   Configuration = Struct.new(:registry, :timeout)
 
-  # Internal: Wrapper object for pre-rendered OC templates.
+  # Internal: Wrapper object for unrendered OC templates.
   #
   # src  - String for the template URL.
   # type - String for template engine type.

--- a/lib/opencomponents/component.rb
+++ b/lib/opencomponents/component.rb
@@ -25,7 +25,7 @@ module OpenComponents
     attr_reader :type
 
     # Public: Returns the String render mode of the component as served by the
-    #   registry. Generally either `rendered` or `pre-rendered`.
+    #   registry. Generally either `rendered` or `unrendered`.
     attr_reader :render_mode
 
     # Public: Initializes a new Component subclass.

--- a/lib/opencomponents/unrendered_component.rb
+++ b/lib/opencomponents/unrendered_component.rb
@@ -1,8 +1,8 @@
 module OpenComponents
-  # Wrapper object for components using the `pre-rendered` rendering mode.
-  class PrerenderedComponent < Component
+  # Wrapper object for components using the `unrendered` rendering mode.
+  class UnrenderedComponent < Component
     # Internal: Default HTTP headers to send when requesting a component.
-    DEFAULT_HEADERS = {accept: 'application/vnd.oc.prerendered+json'}
+    DEFAULT_HEADERS = {accept: 'application/vnd.oc.unrendered+json'}
 
     # Public: Returns a Hash of data to use when rendering the component.
     attr_reader :data
@@ -10,7 +10,7 @@ module OpenComponents
     # Public: Returns a Template with data for rendering the raw component.
     attr_reader :template
 
-    # Public: Initializes a new PrerenderedComponent.
+    # Public: Initializes a new UnrenderedComponent.
     #
     # name - The String name of the component to request.
     # opts - A Hash of options to use when requesting the component

--- a/lib/opencomponents/version.rb
+++ b/lib/opencomponents/version.rb
@@ -1,3 +1,3 @@
 module OpenComponents
-  VERSION = '0.4.0' # :nodoc:
+  VERSION = '0.5.0' # :nodoc:
 end

--- a/spec/lib/opencomponents/unrendered_component_spec.rb
+++ b/spec/lib/opencomponents/unrendered_component_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
-RSpec.describe OpenComponents::PrerenderedComponent do
+RSpec.describe OpenComponents::UnrenderedComponent do
   describe '#load' do
     context 'for the latest component version' do
       context 'with request params' do
         before do
           stub_request(:get, "http://localhost:3030/foobar/").
             with(
-              headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
+              headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
               query: {name: 'foobar'}
             ).
-            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar?name=foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"foobar"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', headers: {})
+            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar?name=foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"foobar"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', headers: {})
         end
 
         subject { described_class.new('foobar', params: {name: 'foobar'}).load }
@@ -32,7 +32,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         end
 
         it 'sets the component render mode' do
-          expect(subject.render_mode).to eq 'pre-rendered'
+          expect(subject.render_mode).to eq 'unrendered'
         end
 
         it 'sets the component data' do
@@ -52,8 +52,8 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         before do
           stub_request(:get, "http://localhost:3030/foobar/").
             with(
-              headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
-            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', headers: {})
+              headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
+            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', headers: {})
         end
 
         subject { described_class.new('foobar').load }
@@ -75,7 +75,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         end
 
         it 'sets the component render mode' do
-          expect(subject.render_mode).to eq 'pre-rendered'
+          expect(subject.render_mode).to eq 'unrendered'
         end
 
         it 'sets the component data' do
@@ -97,10 +97,10 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         before do
           stub_request(:get, "http://localhost:3030/foobar/1.0.0").
             with(
-              headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
+              headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
               query: {name: 'foobar'}
             ).
-            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar/1.0.0?name=foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"1.0.0","data":{"name":"foobar"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', headers: {})
+            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar/1.0.0?name=foobar","type":"oc-component-local","version":"1.0.0","requestVersion":"1.0.0","data":{"name":"foobar"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', headers: {})
         end
 
         subject { described_class.new('foobar', params: {name: 'foobar'}, version: '1.0.0').load }
@@ -122,7 +122,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         end
 
         it 'sets the component render mode' do
-          expect(subject.render_mode).to eq 'pre-rendered'
+          expect(subject.render_mode).to eq 'unrendered'
         end
 
         it 'sets the component data' do
@@ -142,8 +142,8 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         before do
           stub_request(:get, "http://localhost:3030/foobar/1.0.0").
             with(
-              headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
-            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"1.0.0","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', headers: {})
+              headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
+            to_return(status: 200, body: '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"1.0.0","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', headers: {})
         end
 
         subject { described_class.new('foobar', version: '1.0.0').load }
@@ -165,7 +165,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
         end
 
         it 'sets the component render mode' do
-          expect(subject.render_mode).to eq 'pre-rendered'
+          expect(subject.render_mode).to eq 'unrendered'
         end
 
         it 'sets the component data' do
@@ -185,7 +185,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
     context 'for a missing component' do
       before do
         stub_request(:get, "http://localhost:3030/foo/").
-          with(headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
+          with(headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
           to_return(status: 404, body: "", headers: {})
       end
 
@@ -211,8 +211,8 @@ RSpec.describe OpenComponents::PrerenderedComponent do
     context 'with custom HTTP headers' do
       let!(:stub) do
         stub_request(:get, "http://localhost:3030/foobar/").
-          with(:headers => {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
-          to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', :headers => {})
+          with(:headers => {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'Accept-Language'=>'emoji', 'User-Agent'=>'Ruby'}).
+          to_return(:status => 200, :body => '{"href":"http://localhost:3030/foobar/1.0.0","type":"oc-component-local","version":"1.0.0","requestVersion":"","data":{"name":"Todd"},"template":{"src":"http://localhost:3030/foobar/1.0.0/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', :headers => {})
       end
 
       subject { described_class.new('foobar', headers: {accept_language: 'emoji'}).load }
@@ -276,16 +276,16 @@ RSpec.describe OpenComponents::PrerenderedComponent do
     before do
         stub_request(:get, "http://localhost:3030/foobar/").
           with(
-            headers: {'Accept'=>'application/vnd.oc.prerendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
+            headers: {'Accept'=>'application/vnd.oc.unrendered+json', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'},
             query: {name: 'foobar'}
           ).
-          to_return(status: 200, body: '{"href":"http://foo.com/bar?name=foobar","type":"some-oc-type","version":"1.0.2","requestVersion":"","data":{"name":"foobar"},"template":{"src":"http://foo.com/bar/1.0.2/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"pre-rendered"}', headers: {})
+          to_return(status: 200, body: '{"href":"http://foo.com/bar?name=foobar","type":"some-oc-type","version":"1.0.2","requestVersion":"","data":{"name":"foobar"},"template":{"src":"http://foo.com/bar/1.0.2/static/template.js","type":"jade","key":"0fe4b3fb2d6c0810f0d97a222a7e61eb91243bea"},"renderMode":"unrendered"}', headers: {})
 
       component.instance_variable_set(:@href, 'http://foo.com/bar/1.0.1')
       component.instance_variable_set(:@registry_version, '1.0.1')
       component.instance_variable_set(:@request_version, '')
       component.instance_variable_set(:@type, 'some-oc-type')
-      component.instance_variable_set(:@render_mode, 'pre-rendered')
+      component.instance_variable_set(:@render_mode, 'unrendered')
       component.instance_variable_set(:@data, {'name' => 'foobar'})
       component.instance_variable_set(:@template, OpenComponents::Template.new('foo', 'bar', 'baz'))
     end
@@ -297,7 +297,7 @@ RSpec.describe OpenComponents::PrerenderedComponent do
       expect(component.registry_version).to eq '1.0.2'
       expect(component.request_version).to be nil
       expect(component.type).to eq 'some-oc-type'
-      expect(component.render_mode).to eq 'pre-rendered'
+      expect(component.render_mode).to eq 'unrendered'
       expect(component.data).to eq({'name' => 'foobar'})
       expect(component.template).to eq OpenComponents::Template.new(
         'http://foo.com/bar/1.0.2/static/template.js',


### PR DESCRIPTION
This should allow integration with oc `0.19.0` that now prefers `unrendered` instead of `pre-rendered` ;)
https://github.com/opentable/oc/issues/87
Needs good review as I never wrote any Ruby before :+1: 
